### PR TITLE
Allow organization resource update by any parent organization and view organization by same organization

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -191,7 +191,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
-        validateOrganizationAllowedToAccess(organizationId);
+        validateOrganizationAllowedToAccess(organizationId, true);
         Organization organization = organizationManagementDAO.getOrganization(organizationId.trim());
 
         if (organization == null) {
@@ -269,7 +269,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
-        validateOrganizationAllowedToAccess(organizationId);
+        validateOrganizationAllowedToAccess(organizationId, false);
         validateOrganizationDelete(organizationId);
         Organization organization = organizationManagementDAO.getOrganization(organizationId);
         if (organization == null) {
@@ -296,7 +296,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
         organizationId = organizationId.trim();
-        validateOrganizationAllowedToAccess(organizationId);
+        validateOrganizationAllowedToAccess(organizationId, false);
         if (!isOrganizationExistById(organizationId)) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
         }
@@ -321,7 +321,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
         organizationId = organizationId.trim();
-        validateOrganizationAllowedToAccess(organizationId);
+        validateOrganizationAllowedToAccess(organizationId, false);
         if (!isOrganizationExistById(organizationId)) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
         }
@@ -855,10 +855,15 @@ public class OrganizationManagerImpl implements OrganizationManager {
         return OrganizationManagementDataHolder.getInstance().getTenantMgtService();
     }
 
-    private void validateOrganizationAllowedToAccess(String organizationId) throws OrganizationManagementException {
+    private void validateOrganizationAllowedToAccess(String organizationId, boolean allowSameOrg)
+            throws OrganizationManagementException {
 
         String authorizedOrganizationId = getOrganizationId(); // The organization that the user is authorized to access
-        if (!organizationManagementDAO.isImmediateChildOfParent(organizationId, authorizedOrganizationId)) {
+        if (authorizedOrganizationId == null) {
+            authorizedOrganizationId = SUPER_ORG_ID;
+        }
+        if (!(allowSameOrg && StringUtils.equals(authorizedOrganizationId, organizationId)) &&
+                !organizationManagementDAO.isChildOfParent(organizationId, authorizedOrganizationId)) {
             throw handleClientException(ERROR_CODE_UNAUTHORIZED_ORG_ACCESS, organizationId, authorizedOrganizationId);
         }
     }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -191,7 +191,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
-        validateOrganizationAllowedToAccess(organizationId, true);
+        String requestInvokingOrganizationId = getOrganizationId();
+        if (requestInvokingOrganizationId == null) {
+            requestInvokingOrganizationId = SUPER_ORG_ID;
+        }
+        validateOrganizationAccess(requestInvokingOrganizationId, organizationId, true);
         Organization organization = organizationManagementDAO.getOrganization(organizationId.trim());
 
         if (organization == null) {
@@ -269,7 +273,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
-        validateOrganizationAllowedToAccess(organizationId, false);
+        String requestInvokingOrganizationId = getOrganizationId();
+        if (requestInvokingOrganizationId == null) {
+            requestInvokingOrganizationId = SUPER_ORG_ID;
+        }
+        validateOrganizationAccess(requestInvokingOrganizationId, organizationId, false);
         validateOrganizationDelete(organizationId);
         Organization organization = organizationManagementDAO.getOrganization(organizationId);
         if (organization == null) {
@@ -296,7 +304,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
         organizationId = organizationId.trim();
-        validateOrganizationAllowedToAccess(organizationId, false);
+        String requestInvokingOrganizationId = getOrganizationId();
+        if (requestInvokingOrganizationId == null) {
+            requestInvokingOrganizationId = SUPER_ORG_ID;
+        }
+        validateOrganizationAccess(requestInvokingOrganizationId, organizationId, false);
         if (!isOrganizationExistById(organizationId)) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
         }
@@ -321,7 +333,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
         }
         organizationId = organizationId.trim();
-        validateOrganizationAllowedToAccess(organizationId, false);
+        String requestInvokingOrganizationId = getOrganizationId();
+        if (requestInvokingOrganizationId == null) {
+            requestInvokingOrganizationId = SUPER_ORG_ID;
+        }
+        validateOrganizationAccess(requestInvokingOrganizationId, organizationId, false);
         if (!isOrganizationExistById(organizationId)) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId);
         }
@@ -855,16 +871,23 @@ public class OrganizationManagerImpl implements OrganizationManager {
         return OrganizationManagementDataHolder.getInstance().getTenantMgtService();
     }
 
-    private void validateOrganizationAllowedToAccess(String organizationId, boolean allowSameOrg)
-            throws OrganizationManagementException {
+    /**
+     * Allow management access of sub organization from an ancestor organization unless the self-manage is allowed
+     * where the requesting organization can manage itself.
+     *
+     * @param requestInvokingOrganizationId The organization qualifier id where the request is authorized to access.
+     * @param accessedOrganizationId        The id of the organization trying to access.
+     * @param isSelfOrgManageAllowed        Whether the request invoked organization can manage itself.
+     * @throws OrganizationManagementException The exception is thrown when the request invoked organization doesn't
+     *                                         have manage access to the organization which is going to access.
+     */
+    private void validateOrganizationAccess(String requestInvokingOrganizationId, String accessedOrganizationId,
+                                            boolean isSelfOrgManageAllowed) throws OrganizationManagementException {
 
-        String authorizedOrganizationId = getOrganizationId(); // The organization that the user is authorized to access
-        if (authorizedOrganizationId == null) {
-            authorizedOrganizationId = SUPER_ORG_ID;
-        }
-        if (!(allowSameOrg && StringUtils.equals(authorizedOrganizationId, organizationId)) &&
-                !organizationManagementDAO.isChildOfParent(organizationId, authorizedOrganizationId)) {
-            throw handleClientException(ERROR_CODE_UNAUTHORIZED_ORG_ACCESS, organizationId, authorizedOrganizationId);
+        if (!(isSelfOrgManageAllowed && StringUtils.equals(requestInvokingOrganizationId, accessedOrganizationId)) &&
+                !organizationManagementDAO.isChildOfParent(accessedOrganizationId, requestInvokingOrganizationId)) {
+            throw handleClientException(ERROR_CODE_UNAUTHORIZED_ORG_ACCESS, accessedOrganizationId,
+                    requestInvokingOrganizationId);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -256,8 +256,12 @@ public class OrganizationManagementConstants {
                 "Organization %s can't manage organization roles."),
         ERROR_CODE_UNAUTHORIZED_ORG_ROLE_ACCESS("60063", "Organization roles can't be managed from a another " +
                 "organization.", "Organization roles of organization %s can't manage from organization %s."),
-        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS("60064", "Organization can only be managed from immediate parent " +
+        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS("60064", "Organization can only be managed from a parent " +
                 "organization.", "Organization %s can't manage from organization %s."),
+        ERROR_CODE_UNAUTHORIZED_APPLICATION_SHARE("60065", "Applications can be shared only from the " +
+                "organization application resides.", "Application %s can't be shared from organization %s."),
+        ERROR_CODE_UNAUTHORIZED_FRAGMENT_APP_ACCESS("60066", "Fragment applications can be managed only from the " +
+                "organization fragment application resides.", "Application %s can't be managed from organization %s."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -256,12 +256,12 @@ public class OrganizationManagementConstants {
                 "Organization %s can't manage organization roles."),
         ERROR_CODE_UNAUTHORIZED_ORG_ROLE_ACCESS("60063", "Organization roles can't be managed from a another " +
                 "organization.", "Organization roles of organization %s can't manage from organization %s."),
-        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS("60064", "Organization can only be managed from a parent " +
+        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS("60064", "Organization can only be managed from an ancestor " +
                 "organization.", "Organization %s can't manage from organization %s."),
         ERROR_CODE_UNAUTHORIZED_APPLICATION_SHARE("60065", "Applications can be shared only from the " +
-                "organization application resides.", "Application %s can't be shared from organization %s."),
+                "organization that application resides.", "Application %s can't be shared from organization %s."),
         ERROR_CODE_UNAUTHORIZED_FRAGMENT_APP_ACCESS("60066", "Fragment applications can be managed only from the " +
-                "organization fragment application resides.", "Application %s can't be managed from organization %s."),
+                "organization that fragment application resides.", "Application %s can't be managed from organization %s."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -263,10 +263,10 @@ public class OrganizationManagerImplTest {
     }
 
     @Test(expectedExceptions = OrganizationManagementClientException.class)
-    public void testGetOrganization2() throws Exception {
+    public void testGetParentOrganizationFromChildOrganization() throws Exception {
 
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(SUPER_ORG_ID);
-        organizationManager.getOrganization(ORG2_ID, false, false);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(ORG2_ID);
+        organizationManager.getOrganization(ORG1_ID, false, false);
     }
 
     @Test(expectedExceptions = OrganizationManagementClientException.class)
@@ -340,6 +340,7 @@ public class OrganizationManagerImplTest {
         PatchOperation patchOperation = new PatchOperation(PATCH_OP_ADD, PATCH_PATH_ORG_DESCRIPTION,
                 NEW_ORG_DESCRIPTION);
         patchOperations.add(patchOperation);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(SUPER_ORG_ID);
         Organization patchedOrganization = organizationManager.patchOrganization(ORG1_ID, patchOperations);
         assertNotNull(patchedOrganization);
         assertEquals(patchedOrganization.getDescription(), NEW_ORG_DESCRIPTION);


### PR DESCRIPTION
## Purpose

The sub organizations can be managed by immediate parent organization by the enhanced organization access privileges https://github.com/wso2-extensions/identity-organization-management/pull/143. But that is relaxed to allow any parent organization to update/delete organization resources.

Also the organization view permission is further relaxed to allow access from the same organization as the organization meta data like description, name need to be requested from the same organization.
