### PR TITLE
Fix setting database timestamp attributes in filter considering proper datatype

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -276,6 +276,10 @@ public class OrganizationManagementConstants {
         ERROR_CODE_SAME_ORG_NAME_ON_IMMEDIATE_SUB_ORGANIZATIONS_OF_PARENT_ORG("60070",
                 "Given organization name is taken from a sibling organization.", "Given organization " +
                 "name: %s is taken from a sibling organization of parent organization id %s"),
+        ERROR_CODE_INVALID_FILTER_TIMESTAMP_FORMAT("60071", "Unable to retrieve organizations.", "Invalid " +
+                "timestamp format used for filtering."),
+        ERROR_CODE_UNSUPPORTED_FILTER_OPERATION_FOR_ATTRIBUTE("60072", "Unsupported filter operation on attribute.",
+                "The filter operation '%s' on attribute '%s' is not supported."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/FilterQueryBuilder.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/FilterQueryBuilder.java
@@ -18,7 +18,9 @@
 
 package org.wso2.carbon.identity.organization.management.service.model;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -27,6 +29,7 @@ import java.util.Map;
 public class FilterQueryBuilder {
 
     private Map<String, String> stringParameters = new HashMap<>();
+    private List<String> timestampParameters = new ArrayList<>();
     private int count = 1;
     private String filter;
 
@@ -39,6 +42,16 @@ public class FilterQueryBuilder {
 
         stringParameters.put(placeholder + count, value);
         count++;
+    }
+
+    public List<String> getTimestampFilterAttributes() {
+
+        return timestampParameters;
+    }
+
+    public void addTimestampFilterAttributes(String placeholder) {
+
+        timestampParameters.add(placeholder + count);
     }
 
     public void setFilterQuery(String filter) {


### PR DESCRIPTION
## Purpose
- Fix setting timestamp type attribute (related to `UM_CREATED_TIME` and `UM_LAST_MODIFIED` fields) in database query when listing orgainzations.
- Add client exceptions for incorrect timestamp format passed for timestamp related filters and related unsupported operations when listing organizations.