### PR TITLE
Retrieve authenticated username when cross tenant flows.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -583,7 +583,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         parentOrganization.setRef(buildURIForBody(parentId));
     }
 
-    private boolean isUserAuthorizedToCreateChildOrganizationInSuper() throws OrganizationManagementServerException {
+    private boolean isUserAuthorizedToCreateChildOrganizationInSuper() throws OrganizationManagementException {
 
         String username = getAuthenticatedUsername();
         try {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -37,7 +37,6 @@ import org.wso2.carbon.user.core.util.DatabaseUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import javax.sql.DataSource;
@@ -193,11 +192,8 @@ public class Utils {
 
         String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         if (username == null) {
-            Optional<User> maybeUser = organizationUserResidentResolverService.resolveUserFromResidentOrganization(null,
-                    getUserId(), getOrganizationId());
-            if (maybeUser.isPresent()) {
-                return maybeUser.get().getUsername();
-            }
+            return organizationUserResidentResolverService.resolveUserFromResidentOrganization(null,
+                    getUserId(), getOrganizationId()).map(User::getUsername).orElse(null);
         }
         return username;
     }


### PR DESCRIPTION
## Purpose
> The authenticated username is not set in the carbon context for cross tenant flows. When the tenant creation as a part of organization creation, the tenant admin is set as the organization creator. The organization creator can resides in different tenant and request can be initiated from a sub organization hence the tenant admin is not set properly as the authenticated username is null in the carbon context.

## Related Issues
- https://github.com/wso2-enterprise/identity-org-mgt-connector/issues/76