### PR TITLE
Add initial event firing mechanism

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.organization.management.service.filter.FilterTre
 import org.wso2.carbon.identity.organization.management.service.filter.Node;
 import org.wso2.carbon.identity.organization.management.service.filter.OperationNode;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
+import org.wso2.carbon.identity.organization.management.service.listener.OrganizationManagerListener;
 import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 import org.wso2.carbon.identity.organization.management.service.model.ChildOrganizationDO;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
@@ -150,12 +151,14 @@ public class OrganizationManagerImpl implements OrganizationManager {
         validateAddOrganizationRequest(organization);
         setParentOrganization(organization);
         setCreatedAndLastModifiedTime(organization);
+        getListener().preAddOrganization(organization);
         organizationManagementDAO.addOrganization(organization);
         String orgCreatorID = getUserId();
         String orgCreatorName = getAuthenticatedUsername();
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
             createTenant(organization.getId(), orgCreatorID, orgCreatorName);
         }
+        getListener().postAddOrganization(organization);
         return organization;
     }
 
@@ -196,6 +199,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             requestInvokingOrganizationId = SUPER_ORG_ID;
         }
         validateOrganizationAccess(requestInvokingOrganizationId, organizationId, true);
+        getListener().preGetOrganization(organizationId.trim());
         Organization organization = organizationManagementDAO.getOrganization(organizationId.trim());
 
         if (organization == null) {
@@ -229,6 +233,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 organization.setPermissions(permissions);
             }
         }
+
+        getListener().postGetOrganization(organizationId.trim(), organization);
         return organization;
     }
 
@@ -283,6 +289,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (organization == null) {
             return;
         }
+        getListener().preDeleteOrganization(organizationId);
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
             String tenantID = organizationManagementDAO.getAssociatedTenantUUIDForOrganization(organizationId);
             if (StringUtils.isNotBlank(tenantID)) {
@@ -294,6 +301,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             }
         }
         organizationManagementDAO.deleteOrganization(organizationId);
+        getListener().postDeleteOrganization(organizationId);
     }
 
     @Override
@@ -314,8 +322,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
         validateOrganizationPatchOperations(patchOperations, organizationId);
 
+        getListener().prePatchOrganization(organizationId, patchOperations);
         organizationManagementDAO.patchOrganization(organizationId, Instant.now(), patchOperations);
         patchTenantStatus(patchOperations, organizationId);
+
+        getListener().postPatchOrganization(organizationId, patchOperations);
 
         Organization organization = organizationManagementDAO.getOrganization(organizationId);
         if (!SUPER.equals(organization.getName())) {
@@ -344,6 +355,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
 
         validateUpdateOrganizationRequest(currentOrganizationName, organization);
         updateLastModifiedTime(organization);
+
+        getListener().preUpdateOrganization(organizationId, organization);
         organizationManagementDAO.updateOrganization(organizationId, organization);
 
         Organization updatedOrganization = organizationManagementDAO.getOrganization(organizationId);
@@ -354,6 +367,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
             updateTenantStatus(organization.getStatus(), organizationId);
         }
+        getListener().postUpdateOrganization(organizationId, organization);
         return updatedOrganization;
     }
 
@@ -889,5 +903,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_UNAUTHORIZED_ORG_ACCESS, accessedOrganizationId,
                     requestInvokingOrganizationId);
         }
+    }
+
+    private OrganizationManagerListener getListener() {
+
+        return OrganizationManagementDataHolder.getInstance().getOrganizationManagerListener();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -470,7 +470,9 @@ public class OrganizationManagementConstants {
                 "Server encountered an error when checking whether the application: %s already has fragments."),
         ERROR_CODE_ERROR_RESOLVING_MAIN_APPLICATION("65089", "Unable to resolve the main application",
                 "Server encountered an error while resolving the main application for " +
-                        "shared application: %s in shared organization: %s.");
+                        "shared application: %s in shared organization: %s."),
+        ERROR_CODE_ERROR_FIRING_EVENTS("65090", "Error while firing the events",
+                "Server encountered an error while firing the events");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.service.internal;
 
+import org.wso2.carbon.identity.organization.management.service.listener.OrganizationManagerListener;
 import org.wso2.carbon.tenant.mgt.services.TenantMgtService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -29,6 +30,7 @@ public class OrganizationManagementDataHolder {
     private static final OrganizationManagementDataHolder instance = new OrganizationManagementDataHolder();
     private RealmService realmService;
     private TenantMgtService tenantMgtService;
+    private OrganizationManagerListener organizationManagerListener;
 
     public static OrganizationManagementDataHolder getInstance() {
 
@@ -53,5 +55,26 @@ public class OrganizationManagementDataHolder {
     public void setTenantMgtService(TenantMgtService tenantMgtService) {
 
         this.tenantMgtService = tenantMgtService;
+    }
+
+
+    /**
+     * Get {@link OrganizationManagerListener}.
+     *
+     * @return IdentityEventService.
+     */
+    public OrganizationManagerListener getOrganizationManagerListener() {
+
+        return organizationManagerListener;
+    }
+
+    /**
+     * Set {@link OrganizationManagerListener}.
+     *
+     * @param organizationManagerListener Instance of {@link OrganizationManagerListener}.
+     */
+    public void setOrganizationManagerListener(OrganizationManagerListener organizationManagerListener) {
+
+        this.organizationManagerListener = organizationManagerListener;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementServiceComponent.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.identity.organization.management.service.OrganizationMana
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagerImpl;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverServiceImpl;
+import org.wso2.carbon.identity.organization.management.service.listener.OrganizationManagerListener;
 import org.wso2.carbon.tenant.mgt.services.TenantMgtService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -117,5 +118,22 @@ public class OrganizationManagementServiceComponent {
             LOG.debug("Unsetting the Tenant Management Service.");
         }
         OrganizationManagementDataHolder.getInstance().setTenantMgtService(null);
+    }
+
+    @Reference(
+            name = "identity.org.mgt.listener",
+            service = OrganizationManagerListener.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManagerListener"
+    )
+    protected void setOrganizationManagerListener(OrganizationManagerListener organizationManagerListener) {
+
+        OrganizationManagementDataHolder.getInstance().setOrganizationManagerListener(organizationManagerListener);
+    }
+
+    protected void unsetOrganizationManagerListener(OrganizationManagerListener organizationManagerListener) {
+
+        OrganizationManagementDataHolder.getInstance().setOrganizationManagerListener(null);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
@@ -30,6 +30,7 @@ import java.util.List;
 public interface OrganizationManagerListener {
 
     void preAddOrganization(Organization organization) throws OrganizationManagementException;
+    
     void postAddOrganization(Organization organization) throws OrganizationManagementException;
 
     void preGetOrganization(String organizationId) throws OrganizationManagementException;
@@ -38,6 +39,7 @@ public interface OrganizationManagerListener {
             throws OrganizationManagementException;
 
     void preDeleteOrganization(String organizationId) throws OrganizationManagementException;
+    
     void postDeleteOrganization(String organizationId) throws OrganizationManagementException;
 
     void prePatchOrganization(String organizationId, List<PatchOperation> patchOperations) throws

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.service.listener;
+
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+
+import java.util.List;
+
+/**
+ * Listener interface for organization management operations.
+ */
+public interface OrganizationManagerListener {
+
+    void preAddOrganization(Organization organization) throws OrganizationManagementException;
+    void postAddOrganization(Organization organization) throws OrganizationManagementException;
+
+    void preGetOrganization(String organizationId) throws OrganizationManagementException;
+
+    void postGetOrganization(String organizationId, Organization organization)
+            throws OrganizationManagementException;
+
+    void preDeleteOrganization(String organizationId) throws OrganizationManagementException;
+    void postDeleteOrganization(String organizationId) throws OrganizationManagementException;
+
+    void prePatchOrganization(String organizationId, List<PatchOperation> patchOperations) throws
+            OrganizationManagementException;
+
+    void postPatchOrganization(String organizationId, List<PatchOperation> patchOperations) throws
+            OrganizationManagementException;
+
+    void preUpdateOrganization(String organizationId, Organization organization) throws
+            OrganizationManagementException;
+
+    void postUpdateOrganization(String organizationId, Organization organization) throws
+            OrganizationManagementException;
+}

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.organization.management.service.dao.Organization
 import org.wso2.carbon.identity.organization.management.service.dao.impl.OrganizationManagementDAOImpl;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
+import org.wso2.carbon.identity.organization.management.service.listener.OrganizationManagerListener;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
 import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
 import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
@@ -109,6 +110,8 @@ public class OrganizationManagerImplTest {
     public void setUp() throws Exception {
 
         organizationManager = new OrganizationManagerImpl();
+        OrganizationManagementDataHolder.getInstance().setOrganizationManagerListener(mock(
+                OrganizationManagerListener.class));
 
         TestUtils.initiateH2Base();
         TestUtils.mockDataSource();


### PR DESCRIPTION
## Purpose
> Since this component sits higher than the carbon-identity-framework component in the dependency hierarchy, there is no way to fire events. This PR add a listener so that we can implement the listener in lower level of the dependency hierarchy and fire events.