### PR TITLE
Fix for datasource not populating properly

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.context.CarbonContext;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.organization.management.service.constant.Organiz
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
+import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.util.DatabaseUtil;
@@ -107,7 +108,8 @@ public class Utils {
 
         try {
             if (dataSource == null) {
-                dataSource = DatabaseUtil.getRealmDataSource(CarbonContext.getThreadLocalCarbonContext().getUserRealm()
+                dataSource = DatabaseUtil.getRealmDataSource(OrganizationManagementDataHolder.getInstance()
+                        .getRealmService().getTenantUserRealm(MultitenantConstants.SUPER_TENANT_ID)
                         .getRealmConfiguration());
             }
         return new NamedJdbcTemplate(dataSource);


### PR DESCRIPTION
## Purpose
>  The tenants created for Asgardeo organizations consist of different user realm compared to the super tenant. This fix tries to assume all the tenants have the super tenant user realm. This behaviour was there previously also as the datasource being static variable and assigned once, the first request from super tenant will set the datasource with respect to the user realm of the super tenant.

Changes done in the below PRs can be reverted by this.

- https://github.com/wso2-extensions/identity-organization-management-core/pull/9
- https://github.com/wso2-extensions/identity-organization-management/pull/152 