### PR TITLE
Give support to change tenant domain of underlying tenant of an organization instead of the organization id

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -41,6 +41,7 @@ import org.wso2.carbon.identity.organization.management.service.model.Organizati
 import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
 import org.wso2.carbon.identity.organization.management.service.model.ParentOrganizationDO;
 import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+import org.wso2.carbon.identity.organization.management.service.model.TenantTypeOrganization;
 import org.wso2.carbon.stratos.common.exception.TenantManagementClientException;
 import org.wso2.carbon.stratos.common.exception.TenantMgtException;
 import org.wso2.carbon.tenant.mgt.services.TenantMgtService;
@@ -161,8 +162,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
         String orgCreatorEmail =
                 StringUtils.isNotBlank(organization.getCreatorEmail()) ? organization.getCreatorEmail() :
                         "dummyadmin@email.com";
-        if (StringUtils.equals(TENANT.toString(), organization.getType())) {
-            createTenant(organization.getId(), orgCreatorID, orgCreatorName, orgCreatorEmail);
+        // Create a tenant for tenant type organization.
+        if (organization instanceof TenantTypeOrganization) {
+            String tenantDomainName = ((TenantTypeOrganization) organization).getDomainName();
+            createTenant(tenantDomainName, orgCreatorID, orgCreatorName, orgCreatorEmail);
         }
         getListener().postAddOrganization(organization);
         return organization;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/TenantTypeOrganization.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/TenantTypeOrganization.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.service.model;
+
+/**
+ * Tenant type organization.
+ */
+public class TenantTypeOrganization extends Organization {
+
+    private String domainName;
+
+    public TenantTypeOrganization(String domainName) {
+
+        super();
+        this.domainName = domainName;
+    }
+
+    public String getDomainName() {
+
+        return domainName;
+    }
+
+    public void setDomainName(String domainName) {
+
+        this.domainName = domainName;
+    }
+}


### PR DESCRIPTION
## Purpose

- If the organization is tenant-type, it creates an underlying tenant.
- That tenant's domain name will become the organization id.
- But there can be reasons to change the tenant domain name except for the organization id.
- So this change gives the capability to change the tenant domain via the "PRE_ADD_ORGANIZATION" event