### PR TITLE
Added a service to resolve the users' organization hierarchy until resident organization.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -55,12 +55,13 @@ public interface OrganizationUserResidentResolverService {
             throws OrganizationManagementException;
 
     /**
+     * Retrieve organization hierarchy from the accessed child organization to the user's resident organization.
      *
      * @param userId The user ID.
      * @param organizationId The given child organization in the hierarchy.
      * @return The organization hierarchy from the accessed child organization to the user's resident organization.
      * @throws OrganizationManagementException Error occurred while resolving org hierarchy of the user.
      */
-    Optional<List<BasicOrganization>> getHierarchyUptoResidentOrganization(String userId, String organizationId)
+    List<BasicOrganization> getHierarchyUptoResidentOrganization(String userId, String organizationId)
             throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -61,6 +61,6 @@ public interface OrganizationUserResidentResolverService {
      * @return user's organization hierarchy until resident organization
      * @throws OrganizationManagementException Error occurred while resolving org hierarchy of the user.
      */
-    Optional<List<BasicOrganization>> resolveResidentOrganizationHierarchy(String userId, String organizationId)
+    Optional<List<BasicOrganization>> getHierarchyUptoResidentOrganization(String userId, String organizationId)
             throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -19,8 +19,10 @@
 package org.wso2.carbon.identity.organization.management.service;
 
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 import org.wso2.carbon.user.core.common.User;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -50,5 +52,15 @@ public interface OrganizationUserResidentResolverService {
      * @throws OrganizationManagementException Error occurred while resolving resident org of the user.
      */
     Optional<String> resolveResidentOrganization(String userId, String organizationId)
+            throws OrganizationManagementException;
+
+    /**
+     *
+     * @param userId The user ID.
+     * @param organizationId The given child organization in the hierarchy.
+     * @return user's organization hierarchy until resident organization
+     * @throws OrganizationManagementException Error occurred while resolving org hierarchy of the user.
+     */
+    Optional<List<BasicOrganization>> resolveResidentOrganizationHierarchy(String userId, String organizationId)
             throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -58,7 +58,7 @@ public interface OrganizationUserResidentResolverService {
      *
      * @param userId The user ID.
      * @param organizationId The given child organization in the hierarchy.
-     * @return user's organization hierarchy until resident organization
+     * @return The organization hierarchy from the accessed child organization to the user's resident organization.
      * @throws OrganizationManagementException Error occurred while resolving org hierarchy of the user.
      */
     Optional<List<BasicOrganization>> getHierarchyUptoResidentOrganization(String userId, String organizationId)

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -124,7 +124,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
     }
 
     @Override
-    public Optional<List<BasicOrganization>> resolveResidentOrganizationHierarchy
+    public List<BasicOrganization> getHierarchyUptoResidentOrganization
             (String userId, String accessedOrganizationId) throws OrganizationManagementException {
 
         List<BasicOrganization> basicOrganizationList = new ArrayList<>();
@@ -155,7 +155,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
             throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_ROOT_ORG, e, userId);
         }
         Collections.reverse(basicOrganizationList);
-        return Optional.of(basicOrganizationList);
+        return basicOrganizationList;
     }
 
     private String resolveTenantDomainForOrg(String organizationId) throws OrganizationManagementServerException {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.organization.management.service.dao.impl.Organiz
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
+import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -32,6 +33,8 @@ import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -118,6 +121,41 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
             throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_ROOT_ORG, e, userId);
         }
         return Optional.ofNullable(residentOrgId);
+    }
+
+    @Override
+    public Optional<List<BasicOrganization>> resolveResidentOrganizationHierarchy
+            (String userId, String accessedOrganizationId) throws OrganizationManagementException {
+
+        List<BasicOrganization> basicOrganizationList = new ArrayList<>();
+        try {
+            List<String> ancestorOrganizationIds =
+                    organizationManagementDAO.getAncestorOrganizationIds(accessedOrganizationId);
+            if (ancestorOrganizationIds != null) {
+                for (String organizationId : ancestorOrganizationIds) {
+                    String associatedTenantDomainForOrg = resolveTenantDomainForOrg(organizationId);
+                    if (StringUtils.isBlank(associatedTenantDomainForOrg)) {
+                        continue;
+                    }
+                    Optional<String> organizationName = organizationManagementDAO
+                            .getOrganizationNameById(organizationId);
+                    if (organizationName.isPresent()) {
+                        BasicOrganization basicOrganization = new BasicOrganization();
+                        basicOrganization.setId(organizationId);
+                        basicOrganization.setName(organizationName.get());
+                        basicOrganizationList.add(basicOrganization);
+                    }
+                    AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
+                    if (userStoreManager.isExistingUserWithID(userId)) {
+                        break;
+                    }
+                }
+            }
+        } catch (UserStoreException e) {
+            throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_ROOT_ORG, e, userId);
+        }
+        Collections.reverse(basicOrganizationList);
+        return Optional.of(basicOrganizationList);
     }
 
     private String resolveTenantDomainForOrg(String organizationId) throws OrganizationManagementServerException {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -154,6 +154,10 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
         } catch (UserStoreException e) {
             throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_ROOT_ORG, e, userId);
         }
+        /*
+        Organizations will be sorted starting from resident organization (higher level) and ended up with
+        the accessed organization (lower level)
+         */
         Collections.reverse(basicOrganizationList);
         return basicOrganizationList;
     }


### PR DESCRIPTION
## Purpose
> Get the organization hierarchy from the currently accessed organization to the user resident organization.

## Goals
> Properly resolve the organization hierarchy.

## Approach
> Introduced a new service called `resolveResidentOrganizationHierarchy` to get the organization hierarchy as a list of organizations. The list is sorted as higher-level organizations are at the top.