### PR TITLE
Improvement for resolve user from resident organization when the organization support carbon roles

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.organization.management.service.exception.Organi
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
 import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
@@ -77,6 +78,14 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                             user = userStoreManager.getUser(userId, null);
                         } else {
                             continue;
+                        }
+                        /*
+                            When user found from an organization where carbon roles are applied, the organization
+                            permission check has to be skipped
+                         */
+                        if (!Utils.useOrganizationRolesForValidation(organizationId)) {
+                            resolvedUser = user;
+                            break;
                         }
                         // Check whether user has any association against the org the user is trying to access.
                         boolean userHasAccessPermissions =


### PR DESCRIPTION
## Purpose
> While searching user by traversing over the organization hierarchy, once the user found, check the user has at least one organization management permission assigned for the particular organization the user was found. But in the organization hierarchy top level orgs or either 1st level orgs might not have organization roles and hence though user found, the user resolution logic fails.

## Dependant PRs
- https://github.com/wso2-extensions/identity-organization-management-core/pull/24