### PR TITLE
Improve retrieving authenticated username and userId from carbon context for federated user flows

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -144,8 +144,8 @@ public class OrganizationManagerImplTest {
         setFinalStatic(OrganizationManagementAuthorizationManager.class.getDeclaredField("INSTANCE"),
                 authorizationManager);
 
-        when(OrganizationManagementAuthorizationManager.getInstance().isUserAuthorized(anyString(), anyString(),
-                anyString())).thenReturn(true);
+        when(OrganizationManagementAuthorizationManager.getInstance().isUserAuthorized(anyString(),
+                anyString(), anyString())).thenReturn(true);
 
         Organization addedOrganization = organizationManager.addOrganization(sampleOrganization);
         assertNotNull(addedOrganization.getId(), "Created organization id cannot be null");
@@ -250,7 +250,8 @@ public class OrganizationManagerImplTest {
                 mock(OrganizationManagementAuthorizationManager.class);
         setFinalStatic(OrganizationManagementAuthorizationManager.class.getDeclaredField("INSTANCE"),
                 orgAuthorizationManager);
-        when(orgAuthorizationManager.isUserAuthorized(anyString(), anyString(), anyString())).thenReturn(false);
+        when(orgAuthorizationManager.isUserAuthorized(anyString(), anyString(), anyString()))
+                .thenReturn(false);
 
         organizationManager.addOrganization(organization);
     }


### PR DESCRIPTION
## Purpose

Improve authenticated username and userId retrieval from carbon context logic when the authenticated user is a federated user or on a cross tenant flow. For a federated user, the userId can be either null or has a randomly generated value. Also, the username contains the userId as the userId is return from the federated authenticators through the subject claim. Hence the username of the context can be different for federated users. The username and userId retrieval logic should support these cases.

Also the `getAuthenticatedUsername` method is further improved to return a domain qualified username. 