### PR TITLE
Restrict unique organization name for immediate child organizations under the parent organization

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -685,7 +685,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
     private void validateOrganizationPatchOperations(List<PatchOperation> patchOperations, String organizationId)
             throws OrganizationManagementException {
 
-        String newOrgName = null;
         for (PatchOperation patchOperation : patchOperations) {
             // Validate requested patch operation.
             if (StringUtils.isBlank(patchOperation.getOp())) {
@@ -733,7 +732,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
                     throw handleClientException(ERROR_CODE_SUPER_ORG_RENAME, organizationId);
                 }
                 validateOrganizationNameField(value);
-                newOrgName = value;
+                Organization organization = organizationManagementDAO.getOrganization(organizationId);
+                validateOrgNameUniquenessAmongSiblings(organization.getParent().getId(), value);
             }
 
             if (StringUtils.equals(PATCH_PATH_ORG_STATUS, path)) {
@@ -763,12 +763,6 @@ public class OrganizationManagerImpl implements OrganizationManager {
             patchOperation.setPath(path);
             patchOperation.setValue(value);
         }
-
-        if (newOrgName != null) {
-            Organization organization = organizationManagementDAO.getOrganization(organizationId);
-            validateOrgNameUniquenessAmongSiblings(organization.getParent().getId(), newOrgName);
-        }
-
     }
 
     private void patchTenantStatus(List<PatchOperation> patchOperations, String organizationId)

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -93,6 +93,7 @@ public class OrganizationManagementConstants {
     public static final String ORGANIZATION_MGT_CONFIG_FILE = "organization-mgt.xml";
     public static final String IS_CARBON_ROLE_VALIDATION_ENABLED_FOR_LEVEL_ONE_ORGS =
             "LevelOneOrganizationConfigs.EnableCarbonRoleBasedValidation";
+
     /**
      * Contains constants related to filter operations.
      */
@@ -273,8 +274,8 @@ public class OrganizationManagementConstants {
                 "the application with ID %s from the organization with ID %s if the application is shared with all " +
                 "children organizations."),
         ERROR_CODE_SAME_ORG_NAME_ON_IMMEDIATE_SUB_ORGANIZATIONS_OF_PARENT_ORG("60070",
-                "Unable to create the organization due to same organization name found on immediate sub organizations of parent organization",
-                "Organization with same organization name: %s found in the immediate sub organizations of parent organization"),
+                "Given organization name is taken from a sibling organization.", "Given organization " +
+                "name: %s is taken from a sibling organization of parent organization id %s"),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -272,6 +272,9 @@ public class OrganizationManagementConstants {
         ERROR_CODE_INVALID_DELETE_SHARE_REQUEST("60069", "Invalid request.", "Cannot unshare " +
                 "the application with ID %s from the organization with ID %s if the application is shared with all " +
                 "children organizations."),
+        ERROR_CODE_SAME_ORG_NAME_ON_IMMEDIATE_SUB_ORGANIZATIONS_OF_PARENT_ORG("60070",
+                "Unable to create the organization due to same organization name found on immediate sub organizations of parent organization",
+                "Organization with same organization name: %s found in the immediate sub organizations of parent organization"),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -75,6 +75,7 @@ public class OrganizationManagerImplTest {
     private static final String SUPER = "Super";
     private static final String ORG1_NAME = "ABC Builders";
     private static final String ORG2_NAME = "XYZ Builders";
+    private static final String NEW_ORG1_NAME = "ABC Builders New";
     private static final String ORG_DESCRIPTION = "This is a construction company.";
     private static final String NEW_ORG_NAME = "New Org";
     private static final String NEW_ORG_DESCRIPTION = "new sample description.";
@@ -101,6 +102,7 @@ public class OrganizationManagerImplTest {
 
     @BeforeClass
     public void init() {
+
         realmService = mock(RealmService.class);
         userRealm = mock(UserRealm.class);
         authorizationManager = mock(AuthorizationManager.class);
@@ -117,7 +119,7 @@ public class OrganizationManagerImplTest {
         TestUtils.mockDataSource();
 
         Organization organization1 = getOrganization(ORG1_ID, ORG1_NAME, ORG_DESCRIPTION, SUPER_ORG_ID,
-                    STRUCTURAL.toString());
+                STRUCTURAL.toString());
         Organization organization2 = getOrganization(ORG2_ID, ORG2_NAME, ORG_DESCRIPTION, ORG1_ID,
                 STRUCTURAL.toString());
         organizationManagementDAO.addOrganization(organization1);
@@ -459,7 +461,7 @@ public class OrganizationManagerImplTest {
     @Test
     public void testUpdateOrganization() throws Exception {
 
-        Organization sampleOrganization = getOrganization(ORG1_ID, ORG1_NAME, NEW_ORG_DESCRIPTION, SUPER_ORG_ID,
+        Organization sampleOrganization = getOrganization(ORG1_ID, NEW_ORG1_NAME, NEW_ORG_DESCRIPTION, SUPER_ORG_ID,
                 STRUCTURAL.toString());
         Organization updatedOrganization = organizationManager.updateOrganization(ORG1_ID, ORG1_NAME,
                 sampleOrganization);
@@ -488,7 +490,7 @@ public class OrganizationManagerImplTest {
         return new Object[][]{
                 {ORG1_ID, 1},
                 {INVALID_ORG_ID, -1}
-       };
+        };
     }
 
     @Test(dataProvider = "dataForGetOrganizationDepth")
@@ -532,6 +534,7 @@ public class OrganizationManagerImplTest {
     }
 
     private void setFinalStatic(Field field, Object newValue) throws Exception {
+
         field.setAccessible(true);
 
         Field modifiersField = Field.class.getDeclaredField("modifiers");


### PR DESCRIPTION
## Purpose
> With this fix organizations with same name can't be created as immediate child organizations under a particular parent organization.