### PR TITLE
Workaround for user resolve from residence organization issue

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -94,7 +94,11 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                                         .hasUserOrgAssociation(user.getUserID(), accessedOrganizationId);
                         if (userHasAccessPermissions) {
                             resolvedUser = user;
-                            break;
+                            /*
+                                User resident organization logic should be improved based on the user store
+                                configurations in the deployment. So commenting the flow break as a temporary fix.
+                             */
+                            //break;
                         }
                     }
                 }
@@ -125,7 +129,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                         residentOrgId = organizationId;
                         /*
                             User resident organization logic should be improved based on the user store configurations
-                            in the deployment. So commenting the flow break as a temporary fix
+                            in the deployment. So commenting the flow break as a temporary fix.
                          */
                         //break;
                     }
@@ -165,7 +169,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                         residentOrgId = organizationId;
                         /*
                             User resident organization logic should be improved based on the user store configurations
-                            in the deployment. So commenting the flow break as a temporary fix
+                            in the deployment. So commenting the flow break as a temporary fix.
                          */
                         //break;
                     }


### PR DESCRIPTION
## Purpose
>  The user resolve from resident organization should be improved to consider the user store managers while trying resolving users at the each level of the ancestor organizations. As a workaround, traverse through the all the ancestor orgs and conclude the resolved user at the end with respect to the order of base organization to the super organization.

