### PR TITLE
Check user in secondary user store when the user store manager do not check the user in secondary store by default

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/pom.xml
@@ -121,6 +121,7 @@
                             org.wso2.carbon.tenant.mgt.services;version="${carbon.multitenancy.package.import.version.range}",
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.jdbc;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/pom.xml
@@ -121,7 +121,6 @@
                             org.wso2.carbon.tenant.mgt.services;version="${carbon.multitenancy.package.import.version.range}",
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
-                            org.wso2.carbon.user.core.jdbc;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -29,9 +29,9 @@ import org.wso2.carbon.identity.organization.management.service.model.BasicOrgan
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
-import org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -48,6 +48,8 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER_ORG_ID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
+import static org.wso2.carbon.user.core.UserCoreConstants.DOMAIN_SEPARATOR;
+import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME;
 
 /**
  * Service implementation to resolve user's resident organization.
@@ -78,7 +80,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                     String associatedTenantDomainForOrg = resolveTenantDomainForOrg(organizationId);
                     if (associatedTenantDomainForOrg != null) {
                         AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
-                        User user;
+                        User user = null;
                         boolean isValidDomain = false;
                         if (domain != null && userStoreManager.getSecondaryUserStoreManager(domain) != null) {
                             isValidDomain = true;
@@ -87,10 +89,23 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                             user = userStoreManager.getUser(null, userName);
                         } else if (userId != null && userStoreManager.isExistingUserWithID(userId)) {
                             user = userStoreManager.getUser(userId, null);
-                        } else if (userName != null && userStoreManager.getSecondaryUserStoreManager()
-                                .isExistingUser(userName)) {
-                            user = ((UniqueIDJDBCUserStoreManager) userStoreManager.getSecondaryUserStoreManager())
-                                    .getUser(null, userName);
+                        } else if (userName != null) {
+                            boolean userFound = false;
+                            UserStoreManager secondaryUserStoreManager =
+                                    userStoreManager.getSecondaryUserStoreManager();
+                            while (secondaryUserStoreManager != null) {
+                                domain = secondaryUserStoreManager.getRealmConfiguration().getUserStoreProperties()
+                                        .get(PROPERTY_DOMAIN_NAME);
+                                if (userStoreManager.isExistingUser(domain + DOMAIN_SEPARATOR + userName)) {
+                                    user = userStoreManager.getUser(null, domain + DOMAIN_SEPARATOR + userName);
+                                    userFound = true;
+                                    break;
+                                }
+                                secondaryUserStoreManager = secondaryUserStoreManager.getSecondaryUserStoreManager();
+                            }
+                            if (!userFound) {
+                                continue;
+                            }
                         } else {
                             continue;
                         }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
+import org.wso2.carbon.user.core.jdbc.UniqueIDJDBCUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -86,6 +87,10 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                             user = userStoreManager.getUser(null, userName);
                         } else if (userId != null && userStoreManager.isExistingUserWithID(userId)) {
                             user = userStoreManager.getUser(userId, null);
+                        } else if (userName != null && userStoreManager.getSecondaryUserStoreManager()
+                                .isExistingUser(userName)) {
+                            user = ((UniqueIDJDBCUserStoreManager) userStoreManager.getSecondaryUserStoreManager())
+                                    .getUser(null, userName);
                         } else {
                             continue;
                         }


### PR DESCRIPTION
## Purpose
> The custom local user store manager implementations could have some custom implementations to find the user by the username, only from the primary user store when the username is not domain qualified. In these cases, the `resolveUserFromResidentOrganization` method should be robust to check the user in the secondary user store also.