### PR TITLE
Change tenant mgt dependency scope to provided

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>org.wso2.carbon.multitenancy</groupId>
             <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!--Test Dependencies-->


### PR DESCRIPTION
## Purpose
> As a fix for the issue of when mocking the static methods of the Organization utils class, the test cases fails with class not found exception for the tenant management service. Having the provided scope will not cause for transitive dependencies and could resolve the class not found issues of the dependent components when mocking these classes.