### PR TITLE
Add organizationDepthInHierarchy parameter to OrganizationManagerListener.postDeleteOrganization function

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -332,8 +332,9 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 }
             }
         }
+        int organizationDepthInHierarchy = organizationManagementDAO.getOrganizationDepthInHierarchy(organizationId);
         organizationManagementDAO.deleteOrganization(organizationId);
-        getListener().postDeleteOrganization(organizationId);
+        getListener().postDeleteOrganization(organizationId, organizationDepthInHierarchy);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/exception/NotImplementedException.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/exception/NotImplementedException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.service.exception;
+
+/**
+ * The exception to throw when the code is not implemented.
+ */
+public class NotImplementedException extends RuntimeException {
+
+    public NotImplementedException() {
+
+        super();
+    }
+
+    public NotImplementedException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    public NotImplementedException(String message) {
+
+        super(message);
+    }
+
+    public NotImplementedException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.service.listener;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.wso2.carbon.identity.organization.management.service.exception.NotImplementedException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
 import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/listener/OrganizationManagerListener.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.service.listener;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
 import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
@@ -30,7 +31,7 @@ import java.util.List;
 public interface OrganizationManagerListener {
 
     void preAddOrganization(Organization organization) throws OrganizationManagementException;
-    
+
     void postAddOrganization(Organization organization) throws OrganizationManagementException;
 
     void preGetOrganization(String organizationId) throws OrganizationManagementException;
@@ -39,8 +40,15 @@ public interface OrganizationManagerListener {
             throws OrganizationManagementException;
 
     void preDeleteOrganization(String organizationId) throws OrganizationManagementException;
-    
+
+    @Deprecated
     void postDeleteOrganization(String organizationId) throws OrganizationManagementException;
+
+    default void postDeleteOrganization(String organizationId, int organizationDepthInHierarchy)
+            throws OrganizationManagementException {
+
+        throw new NotImplementedException("This method is not implemented.");
+    }
 
     void prePatchOrganization(String organizationId, List<PatchOperation> patchOperations) throws
             OrganizationManagementException;


### PR DESCRIPTION
## Purpose
> $Subject

## Goals
> Add organization depth in hierarchy as a parameter to postDeleteOrganization function which can then pass it to POST_DELETE_ORGANIZATION event to be used in the sub organization tenant deletion process. 

## Dependant PR
> https://github.com/wso2-extensions/identity-organization-management/pull/194
