### PR TITLE
Add method to retrieve a user when the resident organization is known.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -64,4 +64,14 @@ public interface OrganizationUserResidentResolverService {
      */
     List<BasicOrganization> getHierarchyUptoResidentOrganization(String userId, String organizationId)
             throws OrganizationManagementException;
+
+    /**
+     * Retrieve the user when the resident organization is known.
+     *
+     * @param userId The user ID.
+     * @param residentOrgId The user's resident organization.
+     * @return User object based on user's resident organization.
+     * @throws OrganizationManagementException Error occurred while resolving org hierarchy of the user.
+     */
+    User getUserFromResidentOrgId(String userId, String residentOrgId) throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -73,5 +73,6 @@ public interface OrganizationUserResidentResolverService {
      * @return User object based on user's resident organization.
      * @throws OrganizationManagementException Error occurred while resolving org hierarchy of the user.
      */
-    User getUserFromResidentOrgId(String userId, String residentOrgId) throws OrganizationManagementException;
+    Optional<String> getUserNameFromResidentOrgId(String userId, String residentOrgId)
+            throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -82,11 +82,8 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                     if (StringUtils.isNotBlank(associatedTenantDomainForOrg)) {
                         AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
                         User user = null;
-                        boolean isValidDomain = false;
-                        if (StringUtils.isNotBlank(domain) &&
-                                userStoreManager.getSecondaryUserStoreManager(domain) != null) {
-                            isValidDomain = true;
-                        }
+                        boolean isValidDomain = StringUtils.isNotBlank(domain) &&
+                                userStoreManager.getSecondaryUserStoreManager(domain) != null;
                         if (StringUtils.isNotBlank(userName) && isValidDomain &&
                                 userStoreManager.isExistingUser(userName)) {
                             user = userStoreManager.getUser(null, userName);
@@ -94,9 +91,9 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                             user = userStoreManager.getUser(userId, null);
                         } else if (StringUtils.isNotBlank(userName) &&
                                 UserCoreUtil.removeDomainFromName(userName).equals(userName)) {
-                            /**
-                             * Try to find the user from the secondary user stores when the username is not domain
-                             * qualified.
+                            /*
+                              Try to find the user from the secondary user stores when the username is not domain
+                              qualified.
                              */
                             boolean userFound = false;
                             UserStoreManager secondaryUserStoreManager =

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -68,10 +68,10 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
         String domain = null;
 
         try {
-            if (userName == null && userId == null) {
+            if (StringUtils.isBlank(userName) && StringUtils.isBlank(userId)) {
                 throw handleClientException(ERROR_CODE_NO_USERNAME_OR_ID_TO_RESOLVE_USER_FROM_RESIDENT_ORG);
             }
-            if (userName != null) {
+            if (StringUtils.isNotBlank(userName)) {
                 domain = UserCoreUtil.extractDomainFromName(userName);
             }
             List<String> ancestorOrganizationIds =
@@ -79,18 +79,21 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
             if (ancestorOrganizationIds != null) {
                 for (String organizationId : ancestorOrganizationIds) {
                     String associatedTenantDomainForOrg = resolveTenantDomainForOrg(organizationId);
-                    if (associatedTenantDomainForOrg != null) {
+                    if (StringUtils.isNotBlank(associatedTenantDomainForOrg)) {
                         AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
                         User user = null;
                         boolean isValidDomain = false;
-                        if (domain != null && userStoreManager.getSecondaryUserStoreManager(domain) != null) {
+                        if (StringUtils.isNotBlank(domain) &&
+                                userStoreManager.getSecondaryUserStoreManager(domain) != null) {
                             isValidDomain = true;
                         }
-                        if (userName != null && isValidDomain && userStoreManager.isExistingUser(userName)) {
+                        if (StringUtils.isNotBlank(userName) && isValidDomain &&
+                                userStoreManager.isExistingUser(userName)) {
                             user = userStoreManager.getUser(null, userName);
-                        } else if (userId != null && userStoreManager.isExistingUserWithID(userId)) {
+                        } else if (StringUtils.isNotBlank(userId) && userStoreManager.isExistingUserWithID(userId)) {
                             user = userStoreManager.getUser(userId, null);
-                        } else if (userName != null && UserCoreUtil.removeDomainFromName(userName).equals(userName)) {
+                        } else if (StringUtils.isNotBlank(userName) &&
+                                UserCoreUtil.removeDomainFromName(userName).equals(userName)) {
                             /**
                              * Try to find the user from the secondary user stores when the username is not domain
                              * qualified.
@@ -232,11 +235,9 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
         User user = null;
         try {
             String associatedTenantDomainForOrg = resolveTenantDomainForOrg(userResidentOrganizationId);
-            if (associatedTenantDomainForOrg != null) {
+            if (StringUtils.isNotBlank(associatedTenantDomainForOrg)) {
                 AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
-                if (userId != null && userStoreManager.isExistingUserWithID(userId)) {
-                    user = userStoreManager.getUser(userId, null);
-                }
+                user = userStoreManager.getUser(userId, null);
             }
         } catch (UserStoreException | OrganizationManagementServerException e) {
             throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_USER_IN_RESIDENT_ORG, e,

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -226,21 +226,21 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
         return basicOrganizationList;
     }
 
-    public User getUserFromResidentOrgId(String userId, String userResidentOrganizationId)
+    public Optional<String> getUserNameFromResidentOrgId(String userId, String userResidentOrganizationId)
             throws OrganizationManagementException {
 
-        User user = null;
+        String username = null;
         try {
             String associatedTenantDomainForOrg = resolveTenantDomainForOrg(userResidentOrganizationId);
             if (StringUtils.isNotBlank(associatedTenantDomainForOrg)) {
                 AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
-                user = userStoreManager.getUser(userId, null);
+                username = userStoreManager.getUser(userId, null).getUsername();
             }
         } catch (UserStoreException | OrganizationManagementServerException e) {
             throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_USER_IN_RESIDENT_ORG, e,
                     userId, userResidentOrganizationId);
         }
-        return user;
+        return Optional.ofNullable(username);
     }
 
     private String resolveTenantDomainForOrg(String organizationId) throws OrganizationManagementServerException {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -540,7 +540,10 @@ public class OrganizationManagementConstants {
                 "Server encountered an error when deleting shared application roles related to" +
                         " parent application: %s in organization: %s."),
         ERROR_CODE_ERROR_DELETING_USER_ROLE_ASSIGNMENTS("65098", "Unable to remove the user from the roles.",
-                "Server encountered an error while removing the user id: %s from the roles.");
+                "Server encountered an error while removing the user id: %s from the roles."),
+        ERROR_CODE_ERROR_WHILE_RESOLVING_USER_IN_RESIDENT_ORG("65099",
+                "Error while resolving user in resident organization.",
+                "Error while resolving user: %s in resident organization with ID: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -555,7 +555,7 @@ public class OrganizationManagementConstants {
                 "service host url not found.", "Configuration could not be found for tenant deletion " +
                 "service host url."),
         ERROR_CODE_ERROR_RETRIEVING_IDENTITY_SERVER_HOST_URL("65104", "Identity server host url not found.",
-                "Configuration could not be found for identity server host url."),;
+                "Configuration could not be found for identity server host url."),
         ERROR_CODE_ERROR_WHILE_RESOLVING_USER_IN_RESIDENT_ORG("65105",
                 "Error while resolving user in resident organization.",
                 "Error while resolving user: %s in resident organization with ID: %s.");


### PR DESCRIPTION
## Purpose
> Add method to retrieve a user when the resident organization is known. This is a helping service method for implementations in https://github.com/wso2-extensions/identity-organization-management/pull/200

## Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/15292